### PR TITLE
Fixed incorrect feature symbol color on line features.

### DIFF
--- a/layer2kmz.py
+++ b/layer2kmz.py
@@ -326,7 +326,7 @@ class kmlprocess():
                                          "png", QSize(30, 30))
                         styles.append([name, {"iconfile": imgname}])
                     elif lyrGeo == 1: ## Line case
-                        color = "%x" % symb.color().rgba()
+                        color = argb2abgr("%x" % symb.color().rgba())
                         width = symb.width()
                         styles.append([name, {"color": color, "width": width}])
                     elif lyrGeo == 2: ## Polygon case


### PR DESCRIPTION
Exported line colors were not the same color as defined in .qgs document. `color` assignment for line features in `kmlprocess.setStyles()` was missing call to `argb2abgr()`.